### PR TITLE
Axios Cancel Request breaks Response copier

### DIFF
--- a/src/cachios.js
+++ b/src/cachios.js
@@ -3,6 +3,9 @@ var NodeCache = require('node-cache');
 var extendPrototype = require('./extendPrototype');
 
 function defaultCacheIdentifer(config) {
+  if (!config) {
+    config = {};
+  }
   return {
     method: config.method,
     url: config.url,
@@ -12,6 +15,9 @@ function defaultCacheIdentifer(config) {
 }
 
 function defaultResponseCopier(response) {
+  if (!response) {
+    response = {};
+  }
   return {
     status: response.status,
     data: response.data,

--- a/src/cachios.js
+++ b/src/cachios.js
@@ -3,9 +3,6 @@ var NodeCache = require('node-cache');
 var extendPrototype = require('./extendPrototype');
 
 function defaultCacheIdentifer(config) {
-  if (!config) {
-    config = {};
-  }
   return {
     method: config.method,
     url: config.url,

--- a/tests/cancel.spec.js
+++ b/tests/cancel.spec.js
@@ -14,7 +14,11 @@ describe('cachios cancelling', () => {
 
   test('nothing should explode if a request is cancelled', (done) => {
     jest.useFakeTimers();
-
+    axios.interceptors.response.use( (response) => {
+      return response
+    }, (error) => {
+      return Promise.reject(error);
+    })
     const cachiosInstance = cachios.create(axios);
     const url = 'http://localhost/fake-url';
 

--- a/tests/getCacheIdentifier.spec.js
+++ b/tests/getCacheIdentifier.spec.js
@@ -20,10 +20,6 @@ describe('cachios.getCacheIdentifier', () => {
     expect(cachios.getCacheIdentifier({}) === undefined).toBe(false);
   });
 
-  test('should work with an null response', () => {
-    expect(cachios.getCacheIdentifier(null)).toBeDefined();
-  });
-
   test('should be used to identify cache', (done) => {
     const instance = cachios.create(axios);
     const url = 'http://localhost/fake-url';

--- a/tests/getCacheIdentifier.spec.js
+++ b/tests/getCacheIdentifier.spec.js
@@ -20,6 +20,10 @@ describe('cachios.getCacheIdentifier', () => {
     expect(cachios.getCacheIdentifier({}) === undefined).toBe(false);
   });
 
+  test('should work with an null response', () => {
+    expect(cachios.getCacheIdentifier(null)).toBeDefined();
+  });
+
   test('should be used to identify cache', (done) => {
     const instance = cachios.create(axios);
     const url = 'http://localhost/fake-url';

--- a/tests/getResponseCopy.spec.js
+++ b/tests/getResponseCopy.spec.js
@@ -20,6 +20,10 @@ describe('cachios.getResponseCopy', () => {
     expect(cachios.getResponseCopy({})).toBeDefined();
   });
 
+  test('should work with an null response', () => {
+    expect(cachios.getResponseCopy(null)).toBeDefined();
+  });
+
   test('should be used to copy responses', (done) => {
     const instance = cachios.create(axios);
     const url = 'http://localhost/fake-url';


### PR DESCRIPTION
Hello,
When we cancel a request using axios cancel token, it returns an error object with the cancel message.
This causes an error with `defaultResponseCopier`.

I have added a null check so it doesn't break

Please review and share your thoughts.

Thank you.