### PR TITLE
Workaround #55 by preventing unresolved cancellable requests from being shared

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,11 +3,7 @@
 
 name: Node.js CI
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push]
 
 jobs:
   test:

--- a/tests/cancel.spec.js
+++ b/tests/cancel.spec.js
@@ -19,7 +19,7 @@ describe('cachios cancelling', () => {
     const url = 'http://localhost/fake-url';
 
     const CancelToken = axios.CancelToken;
-    const source = CancelToken.source();
+    let source = CancelToken.source();
 
     const cachiosPromise = cachiosInstance.get(url, {
       cancelToken: source.token,
@@ -35,6 +35,21 @@ describe('cachios cancelling', () => {
       // we should receive the normal axios cancel exception here
       // (and no "null" issues)
       expect(ex.message).toBe('test');
+    }
+
+    source = CancelToken.source();
+
+    moxios.stubRequest(url, {
+      status: 200,
+    });
+
+    try {
+      const resp = await cachiosInstance.get(url, {
+        cancelToken: source.token,
+      });
+      expect(resp.status).toBe(200);
+    } catch (ex) {
+      throw new Error(`The cancelled request was unexpectedly cached, reproducing https://github.com/AlbinoDrought/cachios/issues/55`);
     }
   });
 });


### PR DESCRIPTION
Fixes #55

## Cause

A mechanism was added in 0368696eb8f7a9181e37adef6d19e05bee7a5aab to prevent sending duplicate identical requests.

If there was a server running this:

```js
const express = require('express');

const app = express();
app.get('/', (req, res) => {
  // send "hello" after 1 second
  console.log('hit');
  setTimeout(() => res.send('hello'), 1000);
});

app.listen(8080);
```

And a user did this:

```js
const cachios = require('cachios');

const requests = [
  cachios.get('http://localhost:8080'),
  cachios.get('http://localhost:8080'),
  cachios.get('http://localhost:8080'),
  cachios.get('http://localhost:8080'),
  cachios.get('http://localhost:8080'),
];

Promise.all(requests).then(console.log);
```

Only one request would actually be made to the server. Internally, the promise from the first `axios.get('http://localhost:8080')` would be shared across all of these calls.

This runs into issues once `cancelTokens` are introduced (#55). Although [Cachios stops sharing these promises once they're rejected](https://github.com/AlbinoDrought/cachios/commit/0368696eb8f7a9181e37adef6d19e05bee7a5aab#diff-07fb569b24b00b58b41db52ccd5a7c54437cadcab3fd639c62da4a1d97b6ee2cR80), code that:

1. Cancels a token for an unresolved request
2. Doesn't yield to the event loop
2. Recreates an identical request

Runs before the Cachios reject handler has been fired:

```js
const axios = require('axios');

const get = (url) => {
  console.log('cachios shares promises here');
  return axios.get(url);
};

let cancelToken;

const getData = (i) =>{
  if (cancelToken) {
    cancelToken.cancel();
  }
  cancelToken = axios.CancelToken.source();
  return get('http://localhost:8080', {
    cancelToken: cancelToken.token
  }).then(() => {
    console.log('promise resolved', i);
  }).catch((thrown) => {
    console.log('promise rejected', i);
  });
}
getData(1);
getData(2);
```

Output:

> cachios shares promises here
> cachios shares promises here
> promise rejected 1
> promise resolved 2

## Workaround

We can avoid this issue by [disabling the sharing of unresolved cancellable requests](https://github.com/AlbinoDrought/cachios/commit/f913a5415d2b7a581cc29b6e93c6df354e821fbd). Requests that provide a `cancelToken` property in their request config will never share their promise or use a shared promise.