### PR TITLE
[ #61 ] Support async cache repositories like `keyv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 3.0.0
+
+Adds support for asynchronous cache repositories like [keyv](https://www.npmjs.com/package/keyv): https://github.com/AlbinoDrought/cachios/issues/61
+
+- If you use a synchronous cache store and have not modified `getCachedValue` or `setCachedValue` in your project, Cachios v3 will be backwards compatible for you. 
+
+- If you modified Cachios to use an asynchronous cache store, or `getCachedValue` to return promises or undefined values, or `setCachedValue` to return promises, Cachios v3 may not be backwards compatible for you. 
+
+The full change can be viewed in 9ee35e125ee7c8dc08c80da0db9f972c222c0462 , human-readable changes summarized below:
+
+## Cache handling before 3.0.0
+
+Results from `getCachedValue` were passed back to caller as-is.
+
+Results from `setCachedValue` were ignored.
+
+## Cache handling after 3.0.0
+
+Results from `getCachedValue` are resolved using `Promise.resolve`. If they are rejected or resolve to `undefined`, Cachios will assume no cached value exists and will send a fresh request using Axios.
+
+Results from `setCachedValue` are passed up the promise chain.
+
 # 2.2.5
 
 Prevents issues with sharing cancelled promises: https://github.com/AlbinoDrought/cachios/issues/55

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ cachios.cache = {
   cacheKey: string
 
   if a value has been set for this `cacheKey`, return it.
-  otherwise, return a falsey value (undefined, false, null)
+  otherwise, return a falsey value (undefined, false, null).
+
+  synchronous, asynchronous, and promise-returning functions are supported.
   */
   get(cacheKey),
 
@@ -192,6 +194,8 @@ cachios.cache = {
 
   store the value `cacheValue` under `cacheKey` for `ttl` seconds.
   if `ttl` is not set, it is assumed the value is stored forever.
+
+  synchronous, asynchronous, and promise-returning functions are supported.
   */
   set(cacheKey, cacheValue, ttl),
 }
@@ -209,6 +213,22 @@ cachios.get('http://example.com/') // not cached
 .then(() => cachios.get('http://example.com/')); // cached
 .then(() => {
   console.log(cachios.cache.itemCount); // 1 item in cache - the first request
+});
+```
+
+Example of persistent cache with `keyv` and `@keyv/sqlite`:
+
+```js
+const cachios = require('cachios');
+const Keyv = require('keyv');
+
+cachios.cache = new Keyv('sqlite://cache.sqlite');
+
+cachios.get('http://example.com/') // not cached
+.then(() => cachios.get('http://example.com/')); // cached
+.then(() => cachios.cache.opts.store.query('SELECT COUNT(*) as count FROM keyv'))
+.then((cacheSize) => {
+  console.log(cacheSize[0].count); // 1 item in cache - the first request
 });
 ```
 

--- a/examples/basic/.gitignore
+++ b/examples/basic/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+node_modules

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -1,0 +1,23 @@
+# Basic Cachios Example
+
+Using Cachios with the default config
+
+```sh
+npm install
+node index.js
+```
+
+## Expected Output
+
+```
+Run 0 took 80 ms
+Run 1 took 0 ms
+Run 2 took 1 ms
+Run 3 took 0 ms
+Run 4 took 0 ms
+Run 5 took 0 ms
+Run 6 took 0 ms
+Run 7 took 0 ms
+Run 8 took 0 ms
+Run 9 took 0 ms
+```

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -1,0 +1,13 @@
+const cachios = require('cachios');
+
+async function main() {
+  for (let i = 0; i < 10; i++) {
+    const start = new Date();
+    await cachios.get('https://example.com/');
+    const end = new Date();
+
+    console.log('Run', i, 'took', end.getTime() - start.getTime(), 'ms');
+  }
+}
+
+main();

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,0 +1,6 @@
+{
+  "license": "PUBLIC DOMAIN",
+  "dependencies": {
+    "cachios": "file:./../.."
+  }
+}

--- a/examples/persistent-cache-sqlite-keyv/.gitignore
+++ b/examples/persistent-cache-sqlite-keyv/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+cache.sqlite
+node_modules

--- a/examples/persistent-cache-sqlite-keyv/README.md
+++ b/examples/persistent-cache-sqlite-keyv/README.md
@@ -1,0 +1,45 @@
+# Persistent Cache Cachios Example
+
+Using Cachios with persistent SQLite cache using [keyv](https://www.npmjs.com/package/keyv) and the [@keyv/sqlite](https://www.npmjs.com/package/@keyv/sqlite) adapter
+
+```sh
+npm install
+# Run once
+node index.js
+# Run again, will load cache from disk
+node index.js
+```
+
+## Expected Output
+
+Run 1:
+
+```
+On boot, cache size is 0
+Run 0 took 78 ms cache size changed by 1
+Run 1 took 0 ms cache size changed by 0
+Run 2 took 0 ms cache size changed by 0
+Run 3 took 0 ms cache size changed by 0
+Run 4 took 0 ms cache size changed by 0
+Run 5 took 0 ms cache size changed by 0
+Run 6 took 1 ms cache size changed by 0
+Run 7 took 0 ms cache size changed by 0
+Run 8 took 0 ms cache size changed by 0
+Run 9 took 0 ms cache size changed by 0
+```
+
+Run 2:
+
+```
+On boot, cache size is 1
+Run 0 took 3 ms cache size changed by 0
+Run 1 took 1 ms cache size changed by 0
+Run 2 took 0 ms cache size changed by 0
+Run 3 took 0 ms cache size changed by 0
+Run 4 took 0 ms cache size changed by 0
+Run 5 took 0 ms cache size changed by 0
+Run 6 took 1 ms cache size changed by 0
+Run 7 took 0 ms cache size changed by 0
+Run 8 took 1 ms cache size changed by 0
+Run 9 took 0 ms cache size changed by 0
+```

--- a/examples/persistent-cache-sqlite-keyv/index.js
+++ b/examples/persistent-cache-sqlite-keyv/index.js
@@ -1,0 +1,25 @@
+const cachios = require('cachios');
+const Keyv = require('keyv');
+
+cachios.cache = new Keyv('sqlite://cache.sqlite');
+
+async function getCacheCount() {
+  const cacheSize = await cachios.cache.opts.store.query('SELECT COUNT(*) as count FROM keyv');
+  return cacheSize[0].count;
+}
+
+async function main() {
+  let cacheSize = await getCacheCount();
+  console.log('On boot, cache size is', cacheSize);
+  for (let i = 0; i < 10; i++) {
+    const start = new Date();
+    await cachios.get('https://example.com/');
+    const end = new Date();
+    
+    const newCacheSize = await getCacheCount();
+    console.log('Run', i, 'took', end.getTime() - start.getTime(), 'ms', 'cache size changed by', newCacheSize - cacheSize);
+    cacheSize = newCacheSize;
+  }
+}
+
+main();

--- a/examples/persistent-cache-sqlite-keyv/package.json
+++ b/examples/persistent-cache-sqlite-keyv/package.json
@@ -1,0 +1,8 @@
+{
+  "license": "PUBLIC DOMAIN",
+  "dependencies": {
+    "@keyv/sqlite": "^2.0.2",
+    "cachios": "file:./../..",
+    "keyv": "^4.0.3"
+  }
+}

--- a/src/cachios.js
+++ b/src/cachios.js
@@ -48,11 +48,14 @@ Cachios.prototype.request = function request(config) {
   var force = config.force || false;
   var cacheablePromise = !config.cancelToken; // refuse to cache cancellable requests until their promise has resolved
   var cacheKey = this.getCacheKey(config);
-  var cachedValue = this.getCachedValue(cacheKey);
 
-  // if we find a cached value, return it immediately
-  if (cachedValue !== undefined && force !== true) {
-    return Promise.resolve(cachedValue);
+  // if we're not forcing this request to ignore cache,
+  // check for a cached value and return it immediately if found
+  if (force !== true) {
+    var cachedValue = this.getCachedValue(cacheKey);
+    if (cachedValue !== undefined) {
+      return Promise.resolve(cachedValue);
+    }
   }
 
   // if we find a staging promise (a request that has not yet completed, so it is not yet in cache),

--- a/src/cachios.js
+++ b/src/cachios.js
@@ -44,15 +44,19 @@ Cachios.prototype.setCachedValue = function (cacheKey, value, ttl) {
 };
 
 Cachios.prototype.request = function request(config) {
+  return handleRequest(this, config);
+};
+
+function handleRequest(instance, config, force) {
   var ttl = config.ttl;
-  var force = config.force || false;
+  var force = force || config.force || false;
   var cacheablePromise = !config.cancelToken; // refuse to cache cancellable requests until their promise has resolved
-  var cacheKey = this.getCacheKey(config);
+  var cacheKey = instance.getCacheKey(config);
 
   // if we're not forcing this request to ignore cache,
   // check for a cached value and return it immediately if found
   if (force !== true) {
-    var cachedValue = this.getCachedValue(cacheKey);
+    var cachedValue = instance.getCachedValue(cacheKey);
     if (cachedValue !== undefined) {
       return Promise.resolve(cachedValue);
     }
@@ -60,33 +64,33 @@ Cachios.prototype.request = function request(config) {
 
   // if we find a staging promise (a request that has not yet completed, so it is not yet in cache),
   // return it.
-  if (cacheablePromise && this.stagingPromises[cacheKey]) {
-    return this.stagingPromises[cacheKey];
+  if (cacheablePromise && instance.stagingPromises[cacheKey]) {
+    return instance.stagingPromises[cacheKey];
   }
 
   // otherwise, send a real request and cache the value for later
-  var me = this;
-  var pendingPromise = this.axiosInstance.request(config);
+  var pendingPromise = instance.axiosInstance.request(config);
 
   // store the promise in stagingPromises so it can be used before completing
   // we don't store it in the cache immediately because:
   // - we don't want it in the cache if the request fails
   // - our cache backend may not support promises
   if (cacheablePromise) {
-    this.stagingPromises[cacheKey] = pendingPromise;
+    instance.stagingPromises[cacheKey] = pendingPromise;
   }
 
   // once the request successfully completes, store it in cache
   pendingPromise.then(function (resp) {
-    me.setCachedValue(cacheKey, me.getResponseCopy(resp), ttl);
+    instance.setCachedValue(cacheKey, instance.getResponseCopy(resp), ttl);
   }).catch(function () {}).then(function () {
     // always delete the staging promise once the request is complete
     // (finished or failed)
-    delete me.stagingPromises[cacheKey];
+    delete instance.stagingPromises[cacheKey];
   });
+
   // return the original promise
   return pendingPromise;
-};
+}
 
 extendPrototype(Cachios.prototype);
 

--- a/tests/customCache-async.spec.js
+++ b/tests/customCache-async.spec.js
@@ -1,0 +1,170 @@
+const cachios = require('./../src');
+
+describe('cachios.cache async', () => {
+  test('should resolve with the cached value returned with .get', (done) => {
+    const instance = cachios.create();
+    instance.cache = {
+      get: jest.fn().mockReturnValue(Promise.resolve(42)),
+    };
+
+    instance.request({})
+    .then((answer) => {
+      expect(answer).toBe(42);
+    })
+    .then(() => done());
+  });
+
+  test('should send a request if cached value resolves as undefined', (done) => {
+    const response = {
+      status: 200,
+      data: {
+        answer: 42,
+      },
+    };
+
+    const fakeAxios = {
+      request: jest.fn().mockReturnValue(Promise.resolve(response)),
+    };
+
+    const instance = cachios.create(fakeAxios);
+    instance.cache = {
+      get: jest.fn().mockReturnValue(Promise.resolve(undefined)),
+    };
+    
+    instance.request({})
+    .then((answer) => {
+      expect(answer).toBe(response);
+    })
+    .then(() => done());
+  });
+
+  test('should send a request if cached value rejects', (done) => {
+    const response = {
+      status: 200,
+      data: {
+        answer: 42,
+      },
+    };
+
+    const fakeAxios = {
+      request: jest.fn().mockReturnValue(Promise.resolve(response)),
+    };
+
+    const instance = cachios.create(fakeAxios);
+    instance.cache = {
+      get: jest.fn().mockReturnValue(Promise.reject()),
+    };
+    
+    instance.request({})
+    .then((answer) => {
+      expect(answer).toBe(response);
+    })
+    .then(() => done());
+  });
+
+  test('should cache requests when both .get and .set return promises, cache resolves on undefined', (done) => {
+    const cacheData = {};
+    
+    const customCache = {
+      get: (cacheKey) => new Promise((resolve) => resolve(cacheData[cacheKey])),
+      set: (cacheKey, value, ttl) => new Promise((resolve) => {
+        cacheData[cacheKey] = value;
+        resolve();
+      }),
+    };
+    
+    const request = {
+      ttl: 1337,
+    };
+
+    const response = {
+      status: 200,
+      data: {
+        answer: 42,
+      },
+    };
+
+    const fakeAxios = {
+      request: jest.fn().mockReturnValue(Promise.resolve(response)),
+    };
+
+    const instance = cachios.create(fakeAxios);
+    instance.cache = customCache;
+
+    instance.request(request)
+    .then((resp) => {
+      // proper response returned (sanity)
+      expect(resp.status).toBe(200);
+      expect(resp.data.answer).toBe(42);
+
+      // send request again:
+      return instance.request(request);
+    })
+    .then((resp) => {
+      // proper response returned (sanity)
+      expect(resp.status).toBe(200);
+      expect(resp.data.answer).toBe(42);
+    })
+    .then(() => {
+      // ensure only one real request was sent
+      expect(fakeAxios.request.mock.calls.length).toBe(1);
+    })
+    .then(() => done());
+  });
+
+  test('should cache requests when both .get and .set return promises, cache rejects on undefined', (done) => {
+    const cacheData = {};
+    
+    const customCache = {
+      get: (cacheKey) => new Promise((resolve, reject) => {
+        if (cacheData[cacheKey] === undefined) {
+          reject(new Error(cacheKey + ' does not exist in cache!'));
+        } else {
+          resolve(cacheData[cacheKey]);
+        }
+      }),
+      set: (cacheKey, value, ttl) => new Promise((resolve) => {
+        cacheData[cacheKey] = value;
+        resolve();
+      }),
+    };
+    
+    const request = {
+      ttl: 1337,
+    };
+
+    const response = {
+      status: 200,
+      data: {
+        answer: 42,
+      },
+    };
+
+    const fakeAxios = {
+      request: jest.fn().mockReturnValue(Promise.resolve(response)),
+    };
+
+    const instance = cachios.create(fakeAxios);
+    instance.cache = customCache;
+
+    instance.request(request)
+    .then((resp) => {
+      // proper response returned (sanity)
+      expect(resp.status).toBe(200);
+      expect(resp.data.answer).toBe(42);
+
+      // send request again:
+      return instance.request(request);
+    })
+    .then((resp) => {
+      // proper response returned (sanity)
+      expect(resp.status).toBe(200);
+      expect(resp.data.answer).toBe(42);
+    })
+    .then(() => {
+      // ensure only one real request was sent
+      expect(fakeAxios.request.mock.calls.length).toBe(1);
+    })
+    .then(() => done());
+  });
+});


### PR DESCRIPTION
Releasing this as 3.0.0, could be a breaking change for people that depend on modified behaviour of `getCachedValue` or `setCachedValue` in their project. Here's an example of code that would now have different behaviour:

```js
const cachios = require('cachios');
const myCustomCache = {};
cachios.getCachedValue = (key) => Promise.resolve(myCustomCache[key]);
```

Before 3.0, this example could return `undefined` if `key` did not exist in `myCustomCache`.

After 3.0, this example would cause a fresh request to be sent.