### PR TITLE
chore: force axios >= 0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/AlbinoDrought/cachios#readme",
   "dependencies": {
-    "axios": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0",
+    "axios": "^0.21.1",
     "node-cache": "^4.1.1 || ^5.0.0",
     "object-hash": "^2.0.0"
   },


### PR DESCRIPTION
Avoids usage of axios v. <= 0.21.0. Tests passes, and seems to have stellar coverage.

```
 PASS  tests/customCache-async.spec.js
 PASS  tests/create.spec.js
 PASS  tests/customCache.spec.js
 PASS  tests/cancel.spec.js
 PASS  tests/getCacheIdentifier.spec.js
 PASS  tests/getResponseCopy.spec.js
 PASS  tests/integration.spec.js
 PASS  tests/extended.spec.js
--------------------|---------|----------|---------|---------|-------------------
File                | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------|---------|----------|---------|---------|-------------------
All files           |     100 |      100 |     100 |     100 |                   
 cachios.js         |     100 |      100 |     100 |     100 |                   
 extendPrototype.js |     100 |      100 |     100 |     100 |                   
 index.js           |     100 |      100 |     100 |     100 |                   
--------------------|---------|----------|---------|---------|-------------------

Test Suites: 8 passed, 8 total
Tests:       53 passed, 53 total
Snapshots:   0 total
Time:        2.898 s, estimated 3 s
Ran all test suites.
```